### PR TITLE
Fix test to get ready for the ggplot2 major changes

### DIFF
--- a/tests/testthat/test-coef_hist.R
+++ b/tests/testthat/test-coef_hist.R
@@ -15,8 +15,8 @@ test_that(paste("coef_hist creates correct lists with graphs"), {
   coef_plots <- coef_hist(bma_results, kernel = 1)
 
   expect_equal(class(coef_plots), "list")
-  expect_equal(class(coef_plots[[1]]), c("gg","ggplot"))
-  expect_equal(class(coef_plots[[2]]), c("gg","ggplot"))
-  expect_equal(class(coef_plots[[3]]), c("gg","ggplot"))
-  expect_equal(class(coef_plots[[4]]), c("gg","ggplot"))
+  expect_true(ggplot2::is_ggplot(coef_plots[[1]]))
+  expect_true(ggplot2::is_ggplot(coef_plots[[2]]))
+  expect_true(ggplot2::is_ggplot(coef_plots[[3]]))
+  expect_true(ggplot2::is_ggplot(coef_plots[[4]]))
 })


### PR DESCRIPTION
As a package maintainer, I got the following message:

> We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
> The issue is described in [https://github.com/tidyverse/ggplot2/issues/6498](https://github.com/tidyverse/ggplot2/issues/6498), where you're welcome to raise discussion.
> The issue isn't with your packaged code, but with the unit tests found here:
> 
> [https://github.com/cran/bdsm/blob/927c8fbafee0f1f926e72cb2772de21f8aed9088/tests/testthat/test-coef_hist.R#L18-L21](https://github.com/cran/bdsm/blob/927c8fbafee0f1f926e72cb2772de21f8aed9088/tests/testthat/test-coef_hist.R#L18-L21)

This fixes the issue.

We will need to release those changes to CRAN. However, I saw there are other changes merged to `develop`
Please let me know whether we should include in the next release all the changes from `develop`, whether there are more changes coming soon, or whether we should just update this little thing.
