### PR TITLE
Add devbox environment and justfile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,12 @@
 source("renv/activate.R")
+
+# Packages not tracked by renv (Suggests-only dev tools, per
+# renv/settings.json's package.dependency.fields) come from the devbox
+# shell's R_LIBS_SITE instead. Register them as external libraries so renv
+# is aware of them without trying to manage them, and append them after the
+# renv project library so renv-tracked package versions still win.
+devbox_libs <- Sys.getenv("R_LIBS_SITE")
+if (nzchar(devbox_libs)) {
+  devbox_libs <- strsplit(devbox_libs, .Platform$path.sep, fixed = TRUE)[[1]]
+  .libPaths(c(.libPaths(), devbox_libs))
+}

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Exported `join_lagged_col` function.
 * Standardized internal variable naming to R-idiomatic conventions (e.g., `n_` prefix for counts, `df_free` for degrees of freedom).
 * Fixed spelling mistakes and grammar in documentation.
+* Added a `devbox`-based reproducible development environment (`devbox.json`) and a `justfile` with shortcuts for common development tasks (`just test`, `just check`, `just document`, etc.).
 
 # badp 0.4.0
 

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.3/.schema/devbox.schema.json",
+  "packages": [
+    "R@4.4.1",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.pkgdown",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.pkgload",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.rmarkdown",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.roxygen2",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.spelling",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.testthat",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#freetype",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libjpeg",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libpng",
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libtiff",
+    "just@latest"
+  ],
+  "shell": {}
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,178 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "R@4.4.1": {
+      "last_modified": "2024-12-23T21:10:33Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#R",
+      "source": "devbox-search",
+      "version": "4.4.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ib46njlhbhfn4px4xxpwbvmjxlz59pm7-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/z4xsp0rkvl4cq690d5qy1x3maavhvx8d-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/ib46njlhbhfn4px4xxpwbvmjxlz59pm7-R-4.4.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/iw45a4n02z2qiw26f0csfw60n4sk4dcv-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/vvfbvjhib872bs302k62pasqkp3zsfla-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/iw45a4n02z2qiw26f0csfw60n4sk4dcv-R-4.4.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0blmybjnixjhgssqma08zgcv2xcgzlpz-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/b5pzzxhszx0sx37xhfhpgrs7zb1ag128-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/0blmybjnixjhgssqma08zgcv2xcgzlpz-R-4.4.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/k9g3yr4md4v76ds9ypz9yjh0590bgg1m-R-4.4.1",
+              "default": true
+            },
+            {
+              "name": "tex",
+              "path": "/nix/store/wicrjcriiq7l3kfb0v7xp85bw2i4vrng-R-4.4.1-tex"
+            }
+          ],
+          "store_path": "/nix/store/k9g3yr4md4v76ds9ypz9yjh0590bgg1m-R-4.4.1"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#freetype": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#freetype"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libjpeg": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libjpeg"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libpng": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libpng"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libtiff": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#libtiff"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.pkgdown": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.pkgdown"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.pkgload": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.pkgload"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.rmarkdown": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.rmarkdown"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.roxygen2": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.roxygen2"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.spelling": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.spelling"
+    },
+    "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.testthat": {
+      "last_modified": "1970-01-01T00:00:00Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#rPackages.testthat"
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-07-27T08:35:34Z",
+      "resolved": "github:NixOS/nixpkgs/38a4887411571457d700c51c64a6e49ead2ed5ab?lastModified=1785141334&narHash=sha256-kh35kIx7el4Jk8Ki3BH9%2FPn1eZYSYLJ6LMALos0zOy0%3D"
+    },
+    "just@latest": {
+      "last_modified": "2026-07-23T05:10:05Z",
+      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#just",
+      "source": "devbox-search",
+      "version": "1.57.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/197vj26rr8fsd93dzmwmwvjcqw7v24bk-just-1.57.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/0ff1nnr1rg6mnfmcprr9a4lg1ar7jby9-just-1.57.0-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/jzbx2s1nzz7b9cinck1s0w54gr7g8q6x-just-1.57.0-doc"
+            }
+          ],
+          "store_path": "/nix/store/197vj26rr8fsd93dzmwmwvjcqw7v24bk-just-1.57.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ijj0f7avjl3lcahj3pq1prz32mcv1l8p-just-1.57.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/j5wx4dh05fp7gmziwv48j3n222iavl1j-just-1.57.0-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/3a2icqfmckpph7a53rscxd70yzx13ai0-just-1.57.0-doc"
+            }
+          ],
+          "store_path": "/nix/store/ijj0f7avjl3lcahj3pq1prz32mcv1l8p-just-1.57.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/70h070nb8c1l202a4gn58n6mxapbjhl9-just-1.57.0",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/5jqyaddlkly9bng1f3i2migfxp7fs7s0-just-1.57.0-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/hazpa6bzrgc46bbf279wq15dasrid1hj-just-1.57.0-doc"
+            }
+          ],
+          "store_path": "/nix/store/70h070nb8c1l202a4gn58n6mxapbjhl9-just-1.57.0"
+        }
+      }
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,43 @@
+# List available commands
+default:
+    just --list
+
+# Open a shell with the pinned R version and dev-only packages (devbox.json)
+shell:
+    devbox shell
+
+# Restore the renv library (packages declared in renv.lock)
+setup:
+    devbox run -- Rscript -e 'renv::restore(prompt = FALSE)'
+
+# Run the test suite
+test: setup
+    devbox run -- Rscript -e 'testthat::test_local()'
+
+# Regenerate documentation (roxygen2) and NAMESPACE
+document: setup
+    devbox run -- Rscript -e 'roxygen2::roxygenise()'
+
+# Load the package into an interactive R session for development
+load: setup
+    devbox run -- R -e 'pkgload::load_all()'
+
+# Install the package locally
+install: setup
+    devbox run -- R CMD INSTALL .
+
+# Build the source package tarball
+build: setup
+    devbox run -- R CMD build .
+
+# Run full R CMD check
+check: setup
+    devbox run -- bash -c 'R CMD build . && R CMD check --as-cran $(ls -t *.tar.gz | head -n1)'
+
+# Build the pkgdown site
+site: setup
+    devbox run -- Rscript -e 'pkgdown::build_site()'
+
+# Remove build artifacts
+clean:
+    rm -rf ..Rcheck ..Rcheck.Rcheck docs *.tar.gz *.Rcheck


### PR DESCRIPTION

- Add `devbox.json`/`devbox.lock` pinning R 4.4.1 (matching `renv.lock`) plus the Suggests-only tools renv doesn't track (testthat, pkgdown, rmarkdown, spelling, roxygen2, pkgload), all locked to one nixpkgs commit for ABI consistency
- Add `justfile` with shortcuts for common tasks (`just test`, `just document`, `just build`, `just check`, `just site`, `just shell`, ...)
- Extend `.Rprofile` to append devbox's library paths after renv's own, so renv-tracked package versions still take priority
